### PR TITLE
feat: enforce blank line rules as errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,10 @@ module.exports = {
                 "test",
                 "wip"
             ]
-        ]
-    }
+        ],
+        // Raise to error severity
+        'body-leading-blank': [2, 'always'],
+        'footer-leading-blank': [2, 'always'],
+    },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arrai-innovations/commitlint-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arrai-innovations/commitlint-config",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@commitlint/config-conventional": "^19.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arrai-innovations/commitlint-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Arrai Innovation's shareable configuration for commitlint.",
   "files": [
     "index.js"


### PR DESCRIPTION
```
$  g ci -m "test(ViewDestroy): add
 unit tests"
✔ Backed up original state in git stash (92aef1d)
✔ Running tasks for staged files...
✔ Applying modifications from tasks...
✔ Cleaning up temporary files...

> @arrai-innovations/vueda@2.0.0-alpha.14 docs
> echo "#todo: setup jsdoc to markdown"

#todo: setup jsdoc to markdown
⧗   input: test(ViewDestroy): add

 unit tests
⚠   body must have leading blank line [body-leading-blank]

⚠   found 0 problems, 1 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint

[main 6fd6022] test(ViewDestroy): add  unit tests
 1 file changed, 72 insertions(+)
 create mode 100644 tests/unit/lib/views/ViewDestroy.spec.js
```

Block errant newlines in subjects by promoting these rules to an error.